### PR TITLE
MNT: add a note about the IOC's purpose

### DIFF
--- a/iocBoot/ioc-test/st.cmd
+++ b/iocBoot/ioc-test/st.cmd
@@ -1,7 +1,12 @@
 #!../../bin/rhel7-x86_64/test
-# Note: This isn't really intended to be a functional IOC.
-# It's merely for showing off some of whatrecord's inspection utilities
-# and the frontend.
+#
+# pcdshub/ioc-whatrecord-example startup script
+#
+# Note: This isn't really intended to be a functional IOC. It's merely for
+# showing off some of whatrecord's inspection utilities and the frontend.
+# Take a look at the GitHub Actions workflows and the corresponding published
+# gh-pages (which must be configured as the build and deployment source in the
+# repository settings).
 
 < envPaths
 


### PR DESCRIPTION
* This isn't really an IOC but an example deployment of the static pages via GHA
    * I'm hoping after this PR is merged, the docs will appear here: https://pcdshub.github.io/ioc-whatrecord-example
    * If not, the fallback is https://klauer.github.io/ioc-useless-test/#/whatrec
* I've also enabled GHA on this fork and hope that the docs deployment setting will work
* I need to also ask GitHub support to orphan this repository 